### PR TITLE
Add azs back to vpc

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -9,6 +9,7 @@ module "vpc" {
 
   name = "granica-vpc-${var.server_name}"
   cidr = var.vpc_cidr
+  azs  = data.aws_availability_zones.available.names
 
   # Derive private subnets
   # cidrsubnet(base_cidr, new_bits, net_num)


### PR DESCRIPTION
The azs input was mistakenly removed in: https://github.com/granica-ai/granica-setup/pull/15