### PR TITLE
Variable for admin server machine type

### DIFF
--- a/gcp/admin-server.tf
+++ b/gcp/admin-server.tf
@@ -1,6 +1,6 @@
 resource "google_compute_instance" "vm_instance" {
   name         = "granica-admin-server"
-  machine_type = "e2-small"
+  machine_type = var.machine_type
   zone         = var.zone
 
   boot_disk {

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -35,10 +35,10 @@ resource "google_compute_subnetwork" "private_subnet_3" {
 }
 
 resource "google_compute_subnetwork" "public_subnet_1" {
-  name          = "granica-public-subnet-1"
-  ip_cidr_range = "10.47.4.0/24"
-  region        = var.region
-  network       = google_compute_network.vpc_network.self_link
+  name                     = "granica-public-subnet-1"
+  ip_cidr_range            = "10.47.4.0/24"
+  region                   = var.region
+  network                  = google_compute_network.vpc_network.self_link
   private_ip_google_access = false
 
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -28,3 +28,9 @@ variable "granica_username" {
   description = "Name of the Granica user"
   default     = "granica"
 }
+
+variable "machine_type" {
+  type        = string
+  description = "GCP machine type for the admin server"
+  default     = "e2-small"
+}


### PR DESCRIPTION
Make the machine type configurable instead of hard coded to `e2-small` (now the default value).