### PR TITLE
Enable AWS Session Manager

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -49,6 +49,11 @@ resource "aws_iam_role_policy_attachment" "admin-vpc" {
   role       = aws_iam_role.admin.name
 }
 
+resource "aws_iam_role_policy_attachment" "admin-ssm" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.admin.name
+}
+
 data "aws_iam_policy_document" "deploy" {
   statement {
     sid    = "UnrestrictedResourcePermissions"

--- a/customer/fde/aws/iam_users_administer.tf
+++ b/customer/fde/aws/iam_users_administer.tf
@@ -448,3 +448,9 @@ resource "aws_iam_user_policy_attachment" "project-n-oidc-additional-terraform" 
   user       = aws_iam_user.users[count.index].name
   policy_arn = aws_iam_policy.project-n-oidc-additional-terraform.arn
 }
+
+resource "aws_iam_user_policy_attachment" "administer_fde_ssm" {
+  count      = length(var.administer_user_names)
+  user       = aws_iam_user.users[count.index].name
+  policy_arn = aws_iam_policy.fde_ssm.arn
+}

--- a/customer/fde/aws/iam_users_operations.tf
+++ b/customer/fde/aws/iam_users_operations.tf
@@ -171,8 +171,8 @@ resource "aws_iam_policy" "fde_ssm" {
           "ssm:SendCommand"
         ],
         "Resource" : [
-          "arn:aws:ec2:*:401252763139:instance/*",
-          "arn:aws:ssm:*:401252763139:document/SSM-SessionManagerRunShell"
+          "arn:aws:ec2:*:*:instance/*",
+          "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"
         ]
       },
       {

--- a/customer/fde/aws/iam_users_operations.tf
+++ b/customer/fde/aws/iam_users_operations.tf
@@ -158,6 +158,45 @@ resource "aws_iam_policy" "operation_fde_read" {
   })
 }
 
+resource "aws_iam_policy" "fde_ssm" {
+  name        = "granica-fde-session-manager-shell"
+  description = "AWS SSM Session Manager shell access"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ssm:StartSession",
+          "ssm:SendCommand"
+        ],
+        "Resource" : [
+          "arn:aws:ec2:*:401252763139:instance/*",
+          "arn:aws:ssm:*:401252763139:document/SSM-SessionManagerRunShell"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ssm:GetConnectionStatus",
+          "ssm:DescribeInstanceInformation"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ssm:TerminateSession",
+          "ssm:ResumeSession"
+        ],
+        "Resource" : [
+          "arn:aws:ssm:*:*:session/$${aws:userid}-*"
+        ]
+      }
+    ]
+  })
+}
+
 # Create users
 resource "aws_iam_user" "operations-users" {
   count = length(var.operations_user_names)
@@ -175,6 +214,12 @@ resource "aws_iam_user_policy_attachment" "operation_fde_read" {
   count      = length(var.operations_user_names)
   user       = aws_iam_user.operations-users[count.index].name
   policy_arn = aws_iam_policy.operation_fde_read.arn
+}
+
+resource "aws_iam_user_policy_attachment" "operation_fde_ssm" {
+  count      = length(var.operations_user_names)
+  user       = aws_iam_user.operations-users[count.index].name
+  policy_arn = aws_iam_policy.fde_ssm.arn
 }
 
 resource "aws_iam_user_policy_attachment" "operation-ec2-readonly" {


### PR DESCRIPTION
- Give the admin server instance profile permissions so that a session manager connection can be made
- Give the FDE users permissions to start a session manager shell