### PR TITLE
GCP one click deploy: ADC checks

### DIFF
--- a/gcp/deploy_core_infra.sh
+++ b/gcp/deploy_core_infra.sh
@@ -47,6 +47,21 @@ else
   exit 1
 fi
 
+echo "Checking for application-default credentails..."
+if gcloud auth application-default print-access-token > /dev/null 2>&1; then
+  echo "application-default credentails are set"
+else
+  if [ -f "${CLOUDSDK_CONFIG:-}/application_default_credentials.json" ]; then
+    export GOOGLE_APPLICATION_CREDENTIALS=$CLOUDSDK_CONFIG/application_default_credentials.json
+  fi
+  if gcloud auth application-default print-access-token > /dev/null 2>&1; then
+    echo "application-default credentails are set"
+  else
+    echo "application-default credentails are NOT set. Please follow the prompts to login."
+    gcloud auth application-default login
+  fi
+fi
+
 ### STEP 1: Enable GCP APIs
 
 echo "Enabling GCP APIs..."
@@ -126,8 +141,6 @@ EOF
 echo "Updated terraform.tfvars"
 
 ### STEP 6: Deploy
-
-export GOOGLE_APPLICATION_CREDENTIALS=$CLOUDSDK_CONFIG/application_default_credentials.json
 
 echo "Initializing Terraform with backend configuration..."
 terraform init -backend-config=backend.conf

--- a/gcp/deploy_core_infra.sh
+++ b/gcp/deploy_core_infra.sh
@@ -59,6 +59,7 @@ else
   else
     echo "application-default credentails are NOT set. Please follow the prompts to login."
     gcloud auth application-default login
+    export GOOGLE_APPLICATION_CREDENTIALS=$CLOUDSDK_CONFIG/application_default_credentials.json
   fi
 fi
 


### PR DESCRIPTION
Check if we already have application-default credentials and if not then prompt for a
login. application-default credentials should already be set but handle the scenario
where they are not.