### PR TITLE
Readme for custom image

### DIFF
--- a/gcp/admin-server.tf
+++ b/gcp/admin-server.tf
@@ -5,8 +5,7 @@ resource "google_compute_instance" "vm_instance" {
 
   boot_disk {
     initialize_params {
-      image_family  = "granica-admin"
-      image_project = "granica-customer-resources"
+      image = "projects/granica-customer-resources/global/images/granica-admin-server"
     }
   }
 

--- a/gcp/admin-server.tf
+++ b/gcp/admin-server.tf
@@ -5,7 +5,7 @@ resource "google_compute_instance" "vm_instance" {
 
   boot_disk {
     initialize_params {
-      image = "projects/granica-customer-resources/global/images/granica-admin-server"
+      image = var.admin_image_uri
     }
   }
 

--- a/gcp/granica-custom-image-creation-steps.md
+++ b/gcp/granica-custom-image-creation-steps.md
@@ -105,19 +105,6 @@ gcloud compute instances delete centos-prep-vm \
   --zone=us-west2-a \
   --project=granica-customer-resources
 ```
-
----
-
-## Using This Image in Terraform
-
-```hcl
-boot_disk {
-  initialize_params {
-    image = "projects/granica-customer-resources/global/images/granica-admin-server"
-  }
-}
-```
-
 ---
 
 ## Maintenance Tips

--- a/gcp/granica-custom-image-creation-steps.md
+++ b/gcp/granica-custom-image-creation-steps.md
@@ -1,0 +1,126 @@
+# Custom Image Creation Guide: `granica-admin-server`
+
+This guide documents the steps to create a pre-baked custom CentOS 9 image (`granica-admin-server`) with pre-installed dependencies to speed up Granica admin server provisioning.
+
+## Goal
+
+Reduce setup time from \~30 minutes to under 10 minutes by avoiding full `yum update` and pre-installing essential packages.
+
+---
+
+## Target Project
+
+```
+granica-customer-resources
+```
+
+---
+
+## Step-by-Step Instructions
+
+### 1. Create a Temporary CentOS 9 VM
+
+```bash
+gcloud compute instances create centos-prep-vm \
+  --project=granica-customer-resources \
+  --zone=us-west2-a \
+  --machine-type=e2-standard-2 \
+  --image-family=centos-stream-9 \
+  --image-project=centos-cloud \
+  --boot-disk-size=20GB \
+  --boot-disk-type=pd-ssd
+```
+
+---
+
+### 2. SSH into the VM
+
+```bash
+gcloud compute ssh centos-prep-vm --zone=us-west2-a --project=granica-customer-resources
+```
+
+---
+
+### 3. Update System and Install Packages
+
+```bash
+# Become root
+sudo -i
+
+# Update system
+yum -y update
+
+# Install dependencies
+dnf install -y python3 python3-pip gcc \
+               google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin
+
+# Install Python packages
+pip3 install google-cloud-storage pyarrow pandas tabulate
+
+# Clean up cache
+yum clean all
+
+# Exit
+exit
+```
+
+---
+
+### 4. Stop the VM
+
+```bash
+gcloud compute instances stop centos-prep-vm --zone=us-west2-a --project=granica-customer-resources
+```
+
+---
+
+### 5. Create the Custom Image
+
+```bash
+gcloud compute images create granica-admin-server \
+  --project=granica-customer-resources \
+  --source-disk=centos-prep-vm \
+  --source-disk-zone=us-west2-a \
+  --family=granica-admin \
+  --description="Custom CentOS 9 image with pre-installed dependencies for Granica admin server"
+```
+
+---
+
+### 6. Make the Image Publicly Accessible
+
+```bash
+gcloud compute images add-iam-policy-binding granica-admin-server \
+  --project=granica-customer-resources \
+  --member="allAuthenticatedUsers" \
+  --role="roles/compute.imageUser"
+```
+
+---
+
+### 7. Delete the Temporary VM
+
+```bash
+gcloud compute instances delete centos-prep-vm \
+  --zone=us-west2-a \
+  --project=granica-customer-resources
+```
+
+---
+
+## Using This Image in Terraform
+
+```hcl
+boot_disk {
+  initialize_params {
+    image_family  = "granica-admin"
+    image_project = "granica-customer-resources"
+  }
+}
+```
+
+---
+
+## Maintenance Tips
+
+* Recreate the image every 2–4 weeks to ensure it's up to date.

--- a/gcp/granica-custom-image-creation-steps.md
+++ b/gcp/granica-custom-image-creation-steps.md
@@ -113,8 +113,7 @@ gcloud compute instances delete centos-prep-vm \
 ```hcl
 boot_disk {
   initialize_params {
-    image_family  = "granica-admin"
-    image_project = "granica-customer-resources"
+    image = "projects/granica-customer-resources/global/images/granica-admin-server"
   }
 }
 ```

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -18,6 +18,12 @@ variable "boot_image" {
   default     = "centos-cloud/centos-stream-9"
 }
 
+variable "admin_image_uri" {
+  description = "Image URI for the Granica admin server"
+  type        = string
+  default     = "projects/granica-customer-resources/global/images/family/granica-admin"
+}
+
 variable "package_url" {
   type        = string
   description = "URL of the Project N package to install on launch"


### PR DESCRIPTION
1. Readme for creating the custom granica-admin-server image.
2. Make use of granica-admin family name instead of using the exact image name to avoid code change in the future.