### PR TITLE
fix(gcp): install CA certs + set SSL_CERT_FILE on admin server

### DIFF
--- a/gcp/admin-server.tf
+++ b/gcp/admin-server.tf
@@ -59,6 +59,12 @@ resource "google_compute_instance" "vm_instance" {
   echo "Running yum update to catch any recent patches ..."
   sudo yum -y update
 
+  # Ensure CA certs are installed so Python can verify GCE metadata server (metadata.google.internal)
+  sudo yum install -y ca-certificates || true
+  sudo update-ca-trust 2>/dev/null || true
+  # Point Python/Google libs at system CA bundle (avoids SSL CERTIFICATE_VERIFY_FAILED on metadata)
+  grep -q 'SSL_CERT_FILE' /home/${var.granica_username}/.bashrc 2>/dev/null || echo 'export SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt' >> /home/${var.granica_username}/.bashrc
+
   # Install Granica package with retry 
   max_attempts=5
   attempt_num=1


### PR DESCRIPTION
## Summary
Adds CA certificate installation and `SSL_CERT_FILE` export to the GCP admin server bootstrap, so the bundled Python in the granica RPM can verify TLS connections to the GCE metadata server (`metadata.google.internal`).

## Why
On a fresh admin VM, `granica deploy` fails with `SSL: CERTIFICATE_VERIFY_FAILED` when Python/Google libs try to reach the metadata server — the bundled Python doesn't know about the system CA trust store.

## What changes
`gcp/admin-server.tf` — 6 lines added to the bootstrap script:
- `yum install -y ca-certificates`
- `update-ca-trust`
- Append `export SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt` to the granica user's `.bashrc` (idempotent — guarded by `grep -q`)

## History
This PR originally also contained an `owner_email` fallback for Cloud Shell deployments. That problem was solved differently and better by #67 (merged into main). Rebased to keep only the CA cert fix per @jeff-granica's review.

## Risk
Low — additive only. `|| true` and `grep -q` guards make the new steps no-op if already satisfied.
