### PR TITLE
feat(aws): add launch-template modify/delete perms to admin role

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -96,6 +96,7 @@ data "aws_iam_policy_document" "deploy" {
       "ec2:AssociateIamInstanceProfile",
       "ec2:CreateLaunchTemplate",
       "ec2:CreateLaunchTemplateVersion",
+      "ec2:DeleteLaunchTemplate",
       "ec2:CreateSecurityGroup",
       "ec2:AuthorizeSecurityGroupEgress",
       "ec2:RevokeSecurityGroupEgress",


### PR DESCRIPTION
The admin EC2 IAM policy had Create + Read perms for launch templates but no Modify or Delete. EKS managed node groups and Karpenter EC2NodeClasses both create launch templates and rely on them being deletable for clean teardown — without these, `granica teardown` errors with:

    UnauthorizedOperation: not authorized to perform: ec2:DeleteLaunchTemplate
    on resource: arn:aws:ec2:<region>:<account>:launch-template/lt-XXX

Adding:
  * ec2:DeleteLaunchTemplate

Hit during a v3.6.6 teardown on a Quora staging deployment. Likely missed historically because pre-Karpenter teardowns rarely exercised LT delete (EKS node groups own the LT lifecycle in the managed-node-group path). Post-Karpenter migration, LTs are TF-managed and need to be cleaned up explicitly.