### PR TITLE
feat(aws): apply IAM role/policy prefix, path, and permission boundary

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -2,9 +2,37 @@ resource "random_id" "random_suffix" {
   byte_length = 4
 }
 
+locals {
+  # The admin (deployer) role runs deployments and must create IAM roles/policies.
+  # Most boundaries (e.g. ones excluding iam:* from their broad allow) would block
+  # those create actions, so the boundary is applied to it only when explicitly
+  # opted in via permission_boundary_on_admin_role.
+  admin_permissions_boundary = var.permission_boundary_on_admin_role && var.permission_boundary_arn != "" ? var.permission_boundary_arn : null
+
+  # When this deployment uses a custom IAM role/policy prefix or path (matching
+  # krypton's role_name_prefix / role_path / policy_name_prefix / policy_path), the
+  # deployer must also be allowed to manage IAM resources in that namespace. Derived
+  # from the same vars so the scope stays in sync with how krypton names things,
+  # instead of a hand-maintained ARN list. Empty when prefix/path are at their
+  # defaults (the project-n-*/granica-* patterns already cover those).
+  custom_role_namespace   = var.role_path != "/" || var.role_name_prefix != ""
+  custom_policy_namespace = var.policy_path != "/" || var.policy_name_prefix != ""
+  derived_iam_resource_arns = concat(
+    local.custom_role_namespace ? [
+      "arn:aws:iam::*:role${var.role_path}${var.role_name_prefix}*",
+      "arn:aws:iam::*:instance-profile${var.role_path}${var.role_name_prefix}*",
+    ] : [],
+    local.custom_policy_namespace ? [
+      "arn:aws:iam::*:policy${var.policy_path}${var.policy_name_prefix}*",
+    ] : [],
+  )
+}
+
 resource "aws_iam_role" "admin" {
-  name               = "project-n-admin-${random_id.random_suffix.hex}"
-  assume_role_policy = <<EOF
+  name                 = substr("${var.role_name_prefix}project-n-admin-${random_id.random_suffix.hex}", 0, 64)
+  path                 = var.role_path
+  permissions_boundary = local.admin_permissions_boundary
+  assume_role_policy   = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -22,32 +50,37 @@ EOF
 
 resource "aws_iam_instance_profile" "admin" {
   name = aws_iam_role.admin.name
+  path = var.role_path
   role = aws_iam_role.admin.name
 }
 
 resource "aws_iam_policy" "deploy" {
-  name   = "project-n-admin-deploy-${random_id.random_suffix.hex}"
+  name   = "${var.policy_name_prefix}project-n-admin-deploy-${random_id.random_suffix.hex}"
+  path   = var.policy_path
   policy = data.aws_iam_policy_document.deploy.json
 }
 
 resource "aws_iam_policy" "vpc" {
   count = var.manage_vpc && length(var.existing_vpc_id) == 0 ? 1 : 0
 
-  name   = "project-n-admin-vpc-permissions-${random_id.random_suffix.hex}"
+  name   = "${var.policy_name_prefix}project-n-admin-vpc-permissions-${random_id.random_suffix.hex}"
+  path   = var.policy_path
   policy = data.aws_iam_policy_document.vpc.json
 }
 
 resource "aws_iam_policy" "emr" {
   count = var.deploy_emr ? 1 : 0
 
-  name   = "project-n-admin-emr-permissions-${random_id.random_suffix.hex}"
+  name   = "${var.policy_name_prefix}project-n-admin-emr-permissions-${random_id.random_suffix.hex}"
+  path   = var.policy_path
   policy = data.aws_iam_policy_document.emr.json
 }
 
 resource "aws_iam_policy" "efs" {
   count = var.airflow_enabled ? 1 : 0
 
-  name   = "project-n-admin-efs-permissions-${random_id.random_suffix.hex}"
+  name   = "${var.policy_name_prefix}project-n-admin-efs-permissions-${random_id.random_suffix.hex}"
+  path   = var.policy_path
   policy = data.aws_iam_policy_document.efs.json
 }
 
@@ -107,6 +140,7 @@ data "aws_iam_policy_document" "deploy" {
       "ec2:Describe*",
       "ec2:GetLaunchTemplateData",
       "ec2:RunInstances",
+      "ec2:TerminateInstances",
       "eks:CreateCluster",
       "eks:DeleteCluster",
       "eks:ListClusters",
@@ -173,7 +207,11 @@ data "aws_iam_policy_document" "deploy" {
       "iam:UpdateAssumeRolePolicy",
       "iam:UpdateOpenIDConnectProviderThumbprint"
     ]
-    resources = [
+    # Extra ARNs cover IAM resources placed outside the default project-n-*/granica-*
+    # namespaces when this deployment sets role_path / role_name_prefix /
+    # policy_path / policy_name_prefix (e.g. role/OneCloud/CustomerManaged-*,
+    # policy/CustomerManaged_*). Derived in locals; empty when those are at defaults.
+    resources = concat([
       "arn:aws:iam::*:instance-profile/project-n-*",
       "arn:aws:iam::*:instance-profile/granica-*",
       "arn:aws:iam::*:policy/project-n-*",
@@ -185,7 +223,7 @@ data "aws_iam_policy_document" "deploy" {
       "arn:aws:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS",
       "arn:aws:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
       "arn:aws:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
-    ]
+    ], local.derived_iam_resource_arns)
   }
 
   statement {

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -259,6 +259,12 @@ echo 'multi_az           = true' >> /home/ec2-user/config.tfvars
 echo "admin_server_name  = \"granica-admin-server-${var.server_name}\"" >> /home/ec2-user/config.tfvars
 echo "owner_id           = \"${data.aws_caller_identity.current.user_id}\"" >> /home/ec2-user/config.tfvars
 echo "owner_arn          = \"${data.aws_caller_identity.current.arn}\"" >> /home/ec2-user/config.tfvars
+# IAM naming + permission boundary for krypton's aws infra. Names must match krypton's variables.
+echo "role_path               = \"${var.role_path}\"" >> /home/ec2-user/config.tfvars
+echo "role_name_prefix        = \"${var.role_name_prefix}\"" >> /home/ec2-user/config.tfvars
+echo "policy_name_prefix      = \"${var.policy_name_prefix}\"" >> /home/ec2-user/config.tfvars
+echo "policy_path             = \"${var.policy_path}\"" >> /home/ec2-user/config.tfvars
+echo "permission_boundary_arn = \"${var.permission_boundary_arn}\"" >> /home/ec2-user/config.tfvars
 chown ec2-user:ec2-user /home/ec2-user/config.tfvars
 
 max_attempts=5

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -14,6 +14,19 @@ data "aws_route_tables" "existing" {
   vpc_id = var.existing_vpc_id
 }
 
+locals {
+  # IAM naming + boundary lines for krypton's config.tfvars, included only for vars
+  # that differ from their defaults, so we never write blanks/defaults that would
+  # override krypton's own defaults. Empty string when everything is at defaults.
+  iam_config_tfvars = join("", concat(
+    var.role_path != "/" ? ["role_path               = \"${var.role_path}\"\n"] : [],
+    var.role_name_prefix != "" ? ["role_name_prefix        = \"${var.role_name_prefix}\"\n"] : [],
+    var.policy_name_prefix != "" ? ["policy_name_prefix      = \"${var.policy_name_prefix}\"\n"] : [],
+    var.policy_path != "/" ? ["policy_path             = \"${var.policy_path}\"\n"] : [],
+    var.permission_boundary_arn != "" ? ["permission_boundary_arn = \"${var.permission_boundary_arn}\"\n"] : [],
+  ))
+}
+
 module "vpc" {
   count   = length(var.existing_vpc_id) > 0 ? 0 : 1
   source  = "terraform-aws-modules/vpc/aws"
@@ -259,12 +272,9 @@ echo 'multi_az           = true' >> /home/ec2-user/config.tfvars
 echo "admin_server_name  = \"granica-admin-server-${var.server_name}\"" >> /home/ec2-user/config.tfvars
 echo "owner_id           = \"${data.aws_caller_identity.current.user_id}\"" >> /home/ec2-user/config.tfvars
 echo "owner_arn          = \"${data.aws_caller_identity.current.arn}\"" >> /home/ec2-user/config.tfvars
-# IAM naming + permission boundary for krypton's aws infra. Names must match krypton's variables.
-echo "role_path               = \"${var.role_path}\"" >> /home/ec2-user/config.tfvars
-echo "role_name_prefix        = \"${var.role_name_prefix}\"" >> /home/ec2-user/config.tfvars
-echo "policy_name_prefix      = \"${var.policy_name_prefix}\"" >> /home/ec2-user/config.tfvars
-echo "policy_path             = \"${var.policy_path}\"" >> /home/ec2-user/config.tfvars
-echo "permission_boundary_arn = \"${var.permission_boundary_arn}\"" >> /home/ec2-user/config.tfvars
+# IAM naming + permission boundary for krypton's aws infra (only vars set to
+# non-defaults; names must match krypton's variables). Writes nothing at defaults.
+printf '%s' '${local.iam_config_tfvars}' >> /home/ec2-user/config.tfvars
 chown ec2-user:ec2-user /home/ec2-user/config.tfvars
 
 max_attempts=5

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -89,3 +89,58 @@ variable "instance_connect" {
     error_message = "instance_connect must be empty, \"create\", or a security group id starting with sg- (case-insensitive)."
   }
 }
+
+# IAM role / policy naming + permission boundary controls.
+# These mirror the same-named variables in krypton (MR !1987) so the deployer's
+# roles/policies follow the customer's naming convention, and the deployer is
+# scoped to manage IAM in that same namespace (see locals in iam.tf).
+variable "role_name_prefix" {
+  type        = string
+  default     = ""
+  description = "Prefix prepended to every IAM role name created by this module (e.g. \"CustomerManaged-\")."
+}
+
+variable "role_path" {
+  type        = string
+  default     = "/"
+  description = "IAM path for every IAM role created by this module (e.g. \"/OneCloud/\"). Must start and end with \"/\"."
+
+  validation {
+    condition     = can(regex("^/(.*/)?$", var.role_path))
+    error_message = "role_path must start and end with \"/\" (e.g. \"/\" or \"/OneCloud/\")."
+  }
+}
+
+variable "policy_name_prefix" {
+  type        = string
+  default     = ""
+  description = "Prefix prepended to every IAM policy name created by this module (e.g. \"CustomerManaged_\"). Configured separately from role_name_prefix."
+}
+
+variable "policy_path" {
+  type        = string
+  default     = "/"
+  description = "IAM path for every IAM policy created by this module (e.g. \"/\"). Must start and end with \"/\"."
+
+  validation {
+    condition     = can(regex("^/(.*/)?$", var.policy_path))
+    error_message = "policy_path must start and end with \"/\" (e.g. \"/\")."
+  }
+}
+
+variable "permission_boundary_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of an existing IAM policy to attach as the permissions boundary on IAM roles created by this module. Empty string means no boundary."
+}
+
+variable "permission_boundary_on_admin_role" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    Whether to attach permission_boundary_arn to the admin (deployer) role itself.
+    On by default. Note: the admin role must create IAM roles/policies during
+    deployment, so the configured boundary must permit the deployer's iam/ec2/eks
+    write actions; set this false if the boundary would otherwise block them.
+  EOT
+}


### PR DESCRIPTION
Mirror krypton (MR !1987) IAM naming so the deployer's role/policies follow the customer's convention, and scope the deployer to manage IAM in that same namespace:

- add role_name_prefix / role_path / policy_name_prefix / policy_path / permission_boundary_arn (defaults preserve current behavior)
- apply prefix + path to the admin role, its instance profile, and the deploy/vpc/emr/efs policies; trim the role name to 64 chars
- attach the permission boundary to the admin role, gated by permission_boundary_on_admin_role (default true)
- replace the static custom_iam_resource_arns with a list derived from the prefix/path vars (role/<path><prefix>*, instance-profile/..., policy/...); empty at defaults so other deployments are unchanged
- add ec2:TerminateInstances to the deploy policy for teardown