### PR TITLE
fix(aws): restore admin_server ingress to VPC CIDR

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -159,7 +159,7 @@ resource "aws_security_group" "admin_server" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"] // TODO: lock this down to the VPC CIDR
+    cidr_blocks = [local.vpc_cidr_block]
   }
 
 


### PR DESCRIPTION
Commit 3401dda accidentally swapped the egress cidr_blocks between the ec2_instance_connect and admin_server security groups. The ec2_instance_connect SG was correctly locked down to the VPC CIDR, but admin_server was inadvertently opened to 0.0.0.0/0 (contradicting the commit's stated intent). Restore it to [local.vpc_cidr_block].