### PR TITLE
fix(admin-server): replace ICMP ping check with bounded HTTPS probe

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -215,12 +215,21 @@ resource "aws_instance" "admin_server" {
 
 echo "Enter Granica user-data script"
 
-echo "Checking if Google DNS is reachable..."
-until ping -c 1 8.8.8.8; do
-    echo "Waiting for 8.8.8.8 to become reachable..."
-    sleep 1
+# Wait for outbound HTTPS egress before continuing. ICMP/ping may be blocked by
+# the environment; only HTTPS egress is required. Bounded so it cannot spin forever.
+echo "Checking for outbound HTTPS connectivity..."
+connectivity_url="https://s3.amazonaws.com"
+max_wait=300
+waited=0
+until curl --silent --show-error --max-time 10 --output /dev/null "$connectivity_url"; do
+    if [ $waited -ge $max_wait ]; then
+        echo "WARNING: No HTTPS egress to $connectivity_url after $max_wait seconds; proceeding anyway."
+        break
+    fi
+    echo "Waiting for HTTPS egress to become available... ($waited/$max_wait seconds)"
+    sleep 5
+    waited=$((waited + 5))
 done
-echo "8.8.8.8 is reachable!"
 
 while [ -f /var/run/yum.pid ] || pgrep -x yum > /dev/null; do
   echo "Waiting for other yum operations to complete..."

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -231,9 +231,19 @@ until curl --silent --show-error --max-time 10 --output /dev/null "$connectivity
     waited=$((waited + 5))
 done
 
+# Wait for any in-progress yum operation to finish. Bounded so a hung yum or a
+# stale /var/run/yum.pid cannot make this spin forever; after the cap we warn and
+# proceed (the install retry loop below will surface a clear error if yum is wedged).
+yum_max_wait=600
+yum_waited=0
 while [ -f /var/run/yum.pid ] || pgrep -x yum > /dev/null; do
-  echo "Waiting for other yum operations to complete..."
+  if [ $yum_waited -ge $yum_max_wait ]; then
+    echo "WARNING: yum still busy after $yum_max_wait seconds; proceeding anyway."
+    break
+  fi
+  echo "Waiting for other yum operations to complete... ($yum_waited/$yum_max_wait seconds)"
   sleep 5  # waits 5 seconds before checking again
+  yum_waited=$((yum_waited + 5))
 done
 
 # Install pip for root and ec2-user

--- a/gcp/admin-server.tf
+++ b/gcp/admin-server.tf
@@ -48,13 +48,21 @@ resource "google_compute_instance" "vm_instance" {
   echo "admin_server_name     = \"granica-admin-${var.server_name}\"" >> /home/${var.granica_username}/config.tfvars
   echo "owner_id              = \"${local.sanitized_owner_id}\"" >> /home/${var.granica_username}/config.tfvars
 
-  # Check for network connectivity first
-  echo "Checking if Google DNS is reachable..."
-  until ping -c 1 8.8.8.8; do
-    echo "Waiting for 8.8.8.8 to become reachable..."
-    sleep 1
+  # Wait for outbound HTTPS egress before continuing. ICMP/ping may be blocked by
+  # the environment; only HTTPS egress is required. Bounded so it cannot spin forever.
+  echo "Checking for outbound HTTPS connectivity..."
+  connectivity_url="https://www.googleapis.com"
+  max_wait=300
+  waited=0
+  until curl --silent --show-error --max-time 10 --output /dev/null "$connectivity_url"; do
+    if [ $waited -ge $max_wait ]; then
+      echo "WARNING: No HTTPS egress to $connectivity_url after $max_wait seconds; proceeding anyway."
+      break
+    fi
+    echo "Waiting for HTTPS egress to become available... ($waited/$max_wait seconds)"
+    sleep 5
+    waited=$((waited + 5))
   done
-  echo "8.8.8.8 is reachable!"
 
   echo "Running yum update to catch any recent patches ..."
   sudo yum -y update


### PR DESCRIPTION
The admin-server user-data scripts gated bootstrap on an unbounded `ping -c 1 8.8.8.8` loop. This depended on ICMP egress (which may be blocked) and would spin forever if connectivity never came up.

Replace with a `curl` HTTPS probe (the actual egress requirement) that is bounded by a max_wait of 300s, after which it warns and proceeds so downstream yum/package-install retries can surface a clear error rather than the instance hanging at boot.